### PR TITLE
Web server cfg

### DIFF
--- a/android_runner/AndroidRunner/Experiment.py
+++ b/android_runner/AndroidRunner/Experiment.py
@@ -192,7 +192,7 @@ class Experiment(object):
         self.logger.info('Run %s/%s of subject "%s" on %s' % (run, self.repetitions, path, device.name))
         device.shell('logcat -c')
         self.logger.info('Logcat cleared')
-        self.scripts.run('before_run', device, *args, **kwargs)
+        self.scripts.run('before_run', device, path, *args, **kwargs)
 
     def after_launch(self, device, path, run, *args, **kwargs):
         self.scripts.run('after_launch', device, device.id, device.current_activity())

--- a/android_runner/AndroidRunner/WebExperiment.py
+++ b/android_runner/AndroidRunner/WebExperiment.py
@@ -52,7 +52,7 @@ class WebExperiment(Experiment):
 
     def interaction(self, device, path, run, *args, **kwargs):
         browser = args[0]
-        browser.load_url(device, path)
+        browser.load_url(device, "http://192.168.1.172:8000/")          #hardcoded, you can extract only this part of URL from path, but it's always the same
         #time.sleep(5)
         super(WebExperiment, self).interaction(device, path, run, *args, **kwargs)
 

--- a/android_runner/CriticalCSSExperiment/Scripts/Server.py
+++ b/android_runner/CriticalCSSExperiment/Scripts/Server.py
@@ -1,0 +1,25 @@
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+import os
+import multiprocessing
+
+def start(path):
+    old_dir = os.getcwd()
+    os.chdir(path)
+    retval = os.getcwd()
+    print("Directory changed successfully %s" % retval)
+
+    server_address = ('', 8000)
+    server = HTTPServer(server_address, SimpleHTTPRequestHandler)
+    proc = multiprocessing.Process(target = server.handle_request)
+    proc.start()
+    
+    print("Web server started")
+    return
+
+def stop():
+    print("Web server stopped")
+    os.chdir("/home/milica")            #hardcoded, change it to somehow return to android-runner's parent directory
+    retval = os.getcwd()
+    print("Directory restored successfully %s" % retval)
+    return
+

--- a/android_runner/CriticalCSSExperiment/Scripts/after_run.py
+++ b/android_runner/CriticalCSSExperiment/Scripts/after_run.py
@@ -1,6 +1,8 @@
 from AndroidRunner.Device import Device
+from CriticalCSSExperiment.Scripts.Server import stop
 
 
 # noinspection PyUnusedLocal
 def main(device: Device, *args: tuple, **kwargs: dict):
-    pass
+    stop()
+

--- a/android_runner/CriticalCSSExperiment/Scripts/before_run.py
+++ b/android_runner/CriticalCSSExperiment/Scripts/before_run.py
@@ -1,6 +1,8 @@
 from AndroidRunner.Device import Device
+from CriticalCSSExperiment.Scripts.Server import start 
 
 
 # noinspection PyUnusedLocal
-def main(device: Device, *args: tuple, **kwargs: dict):
-    pass
+def main(device: Device, path: str, *args: tuple, **kwargs: dict):
+    start(path)
+


### PR DESCRIPTION
You have two ways to deal with file paths now:

1. If you list the full path for apps in config.json files as if the webserver was running from the root folder (''http://<IP>:8000/subjects/<concrete subject>"), then in WebExperiment.py line 55 extract from this path as substring only 'http://<IP>:8000/' part. In Experiment.py line then extract the rest of the substring from path ('subjects/<concrete subject>') because this is where web server will be started from relative to android-runner. 

2. You can list in config.json files as paths only ''subjects/<concrete subject>'' without prefix for IP and port. Then you don't need to change anything in Experiment.py, but you have to hardcore the 'http://<IP>:8000/' part in WebExperiment.py line 55. This is how it's done now, but option 1 is more elegant and easier to replicate.

Unrelated to this, in Server.py script method stop, return somehow elegantly to green-lab folder from which android-runner is called.